### PR TITLE
fix: AnonCred Wrapper linking issue on Android and CredentialRequestMetadata->get_link_secret_name was being return with double quotation

### DIFF
--- a/anoncred-kmm/anoncreds-kmp/build.gradle.kts
+++ b/anoncred-kmm/anoncreds-kmp/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 apply(plugin = "kotlinx-atomicfu")
-version = "0.4.1"
+version = "0.4.3"
 group = "io.iohk.atala.prism.anoncredskmp"
 
 fun KotlinNativeCompilation.anoncredsCinterops(type: String) {
@@ -54,17 +54,17 @@ fun KotlinNativeCompilation.anoncredsCinterops(type: String) {
                             .absolutePath
                     )
                 }
-//                "ios" -> {
-//                    extraOpts(
-//                        "-libraryPath",
-//                        rootDir
-//                            .resolve("anoncred-wrapper-rust")
-//                            .resolve("target")
-//                            .resolve("ios-universal")
-//                            .resolve("release")
-//                            .absolutePath
-//                    )
-//                }
+                "ios" -> {
+                    extraOpts(
+                        "-libraryPath",
+                        rootDir
+                            .resolve("anoncred-wrapper-rust")
+                            .resolve("target")
+                            .resolve("ios-universal")
+                            .resolve("release")
+                            .absolutePath
+                    )
+                }
                 else -> {
                     throw GradleException("Unsupported linking")
                 }
@@ -82,7 +82,7 @@ kotlin {
             useJUnitPlatform()
         }
     }
-    android {
+    androidTarget {
         publishAllLibraryVariants()
     }
 

--- a/anoncred-kmm/anoncreds-kmp/src/commonTest/kotlin/anoncred/wrapper/IssuerTests.kt
+++ b/anoncred-kmm/anoncreds-kmp/src/commonTest/kotlin/anoncred/wrapper/IssuerTests.kt
@@ -3,7 +3,9 @@ package anoncred.wrapper
 import anoncreds_wrapper.AttributeValues
 import anoncreds_wrapper.CredentialDefinitionConfig
 import anoncreds_wrapper.Issuer
+import anoncreds_wrapper.LinkSecret
 import anoncreds_wrapper.Nonce
+import anoncreds_wrapper.PresentationRequest
 import anoncreds_wrapper.Prover
 import anoncreds_wrapper.RegistryType
 import anoncreds_wrapper.Schema
@@ -14,6 +16,40 @@ import kotlin.test.assertTrue
 
 @AndroidIgnore
 class IssuerTests {
+
+    @Test
+    fun test() {
+        val presentationJSON = """
+            {
+            "requested_attributes":{
+            "attribute_1":{
+            "name":"name",
+            "restrictions":[
+
+            ]
+            }
+            },
+            "requested_predicates":{
+
+            },
+            "name":"presentation_request_1",
+            "nonce":"1177620373658433495312997",
+            "version":"0.1"
+        }
+        """
+        val presentationRequest = PresentationRequest(presentationJSON)
+
+        val requestedAttributes = presentationRequest.getRequestedAttributes()
+        val key = requestedAttributes.keys.first()
+        val requestedAttribute = requestedAttributes.get(key)!!
+        val requestedAttributeJSON = requestedAttribute.getJson()
+
+        println(requestedAttributeJSON)
+
+        val secret = LinkSecret()
+        assertTrue(secret != null)
+    }
+
     @Test
     fun test_Issuer_createSchema() {
         val expectedSchema = Schema("Moussa", "1.0", listOf("name", "age"), "sample:uri")

--- a/anoncred-kmm/anoncreds-kmp/src/jvmTest/kotlin/anoncred/wrapper/Tests.kt
+++ b/anoncred-kmm/anoncreds-kmp/src/jvmTest/kotlin/anoncred/wrapper/Tests.kt
@@ -1,0 +1,42 @@
+package anoncred.wrapper
+
+import anoncreds_wrapper.LinkSecret
+import anoncreds_wrapper.PresentationRequest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class Tests {
+
+    @Test
+    fun test() {
+        val presentationJSON = """
+            {
+            "requested_attributes":{
+            "attribute_1":{
+            "name":"name",
+            "restrictions":[
+
+            ]
+            }
+            },
+            "requested_predicates":{
+
+            },
+            "name":"presentation_request_1",
+            "nonce":"1177620373658433495312997",
+            "version":"0.1"
+        }
+        """
+        val presentationRequest = PresentationRequest(presentationJSON)
+
+        val requestedAttributes = presentationRequest.getRequestedAttributes()
+        val key = requestedAttributes.keys.first()
+        val requestedAttribute = requestedAttributes.get(key)!!
+        val requestedAttributeJSON = requestedAttribute.getJson()
+
+        println(requestedAttributeJSON)
+
+        val secret = LinkSecret()
+        assertTrue(secret != null)
+    }
+}

--- a/anoncred-kmm/build.gradle.kts
+++ b/anoncred-kmm/build.gradle.kts
@@ -5,12 +5,13 @@ plugins {
 
 buildscript {
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         google()
         mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.21")
         classpath("com.android.tools.build:gradle:7.2.2")
         classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.21.0")
     }
@@ -18,6 +19,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
         google()

--- a/anoncred-kmm/settings.gradle.kts
+++ b/anoncred-kmm/settings.gradle.kts
@@ -3,3 +3,12 @@ include(":uniffi-kmm")
 include(":anoncred-wrapper-rust")
 include(":anoncreds-kmp")
 include(":testapp")
+
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}

--- a/anoncred-kmm/testapp/src/androidTest/java/com/example/testapp/IssuerTests.kt
+++ b/anoncred-kmm/testapp/src/androidTest/java/com/example/testapp/IssuerTests.kt
@@ -4,6 +4,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import anoncreds_wrapper.AttributeValues
 import anoncreds_wrapper.CredentialDefinitionConfig
 import anoncreds_wrapper.Issuer
+import anoncreds_wrapper.LinkSecret
+import anoncreds_wrapper.PresentationRequest
 import anoncreds_wrapper.Prover
 import anoncreds_wrapper.RegistryType
 import anoncreds_wrapper.Schema
@@ -15,6 +17,39 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class IssuerTests {
+    @Test
+    fun test() {
+        val presentationJSON = """
+            {
+            "requested_attributes":{
+            "attribute_1":{
+            "name":"name",
+            "restrictions":[
+
+            ]
+            }
+            },
+            "requested_predicates":{
+
+            },
+            "name":"presentation_request_1",
+            "nonce":"1177620373658433495312997",
+            "version":"0.1"
+        }
+        """
+        val presentationRequest = PresentationRequest(presentationJSON)
+
+        val requestedAttributes = presentationRequest.getRequestedAttributes()
+        val key = requestedAttributes.keys.first()
+        val requestedAttribute = requestedAttributes.get(key)!!
+        val requestedAttributeJSON = requestedAttribute.getJson()
+
+        println(requestedAttributeJSON)
+
+        val secret = LinkSecret()
+        assertTrue(secret != null)
+    }
+
     @Test
     fun test_Issuer_createSchema() {
         val expectedSchema = Schema("Moussa", "1.0", listOf("name", "age"), "sample:uri")

--- a/uniffi/src/types/cred_req.rs
+++ b/uniffi/src/types/cred_req.rs
@@ -51,10 +51,92 @@ impl CredentialRequestMetadata {
     }
 
     pub fn get_link_secret_name(&self) -> String {
-        serde_json::to_string(&self.core.link_secret_name).unwrap()
+        self.core.link_secret_name.clone()
     }
 
     pub fn get_nonce(&self) -> Arc<Nonce> {
         return Arc::new(Nonce { anoncreds_nonce: self.core.nonce.try_clone().unwrap() })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use anoncreds_core::data_types::cred_def::CredentialDefinition;
+    use anoncreds_core::issuer::{create_credential_definition, create_credential_offer, create_schema};
+    use anoncreds_core::prover::{create_credential_request};
+    use anoncreds_core::types::{AttributeNames, CredentialDefinitionConfig, CredentialKeyCorrectnessProof, CredentialOffer, LinkSecret, SignatureType};
+    use crate::{AnoncredsError, CredentialRequestMetadata};
+
+    const NEW_IDENTIFIER: &str = "mock:uri";
+    const LEGACY_DID_IDENTIFIER: &str = "DXoTtQJNtXtiwWaZAK3rB1";
+    const LEGACY_SCHEMA_IDENTIFIER: &str = "DXoTtQJNtXtiwWaZAK3rB1:2:example:1.0";
+    const LEGACY_CRED_DEF_IDENTIFIER: &str = "DXoTtQJNtXtiwWaZAK3rB1:3:CL:98153:default";
+
+    const ENTROPY: Option<&str> = Some("entropy");
+    const PROVER_DID: Option<&str> = Some(LEGACY_DID_IDENTIFIER);
+    const LINK_SECRET_ID: &str = "link:secret:id";
+
+    fn cred_def() -> anoncreds_core::Result<(CredentialDefinition, CredentialKeyCorrectnessProof)> {
+        let credential_definition_issuer_id = "sample:id";
+
+        let attr_names = AttributeNames::from(vec!["name".to_owned(), "age".to_owned()]);
+        let schema = create_schema("schema:name", "1.0", "sample:uri", attr_names)?;
+        let cred_def = create_credential_definition(
+            "schema:id",
+            &schema,
+            credential_definition_issuer_id,
+            "default",
+            SignatureType::CL,
+            CredentialDefinitionConfig {
+                support_revocation: true,
+            },
+        )?;
+
+        Ok((cred_def.0, cred_def.2))
+    }
+
+    fn link_secret() -> LinkSecret {
+        LinkSecret::new().unwrap()
+    }
+
+    fn credential_offer(
+        correctness_proof: CredentialKeyCorrectnessProof,
+        is_legacy: bool,
+    ) -> anoncreds_core::Result<CredentialOffer> {
+        if is_legacy {
+            create_credential_offer(
+                LEGACY_SCHEMA_IDENTIFIER,
+                LEGACY_CRED_DEF_IDENTIFIER,
+                &correctness_proof,
+            )
+        } else {
+            create_credential_offer(NEW_IDENTIFIER, NEW_IDENTIFIER, &correctness_proof)
+        }
+    }
+
+    #[test]
+    fn test_get_json() {
+        let (cred_def, correctness_proof) = cred_def().unwrap();
+        let link_secret = link_secret();
+        let credential_offer = credential_offer(correctness_proof, false).unwrap();
+
+        let res = create_credential_request(
+            ENTROPY,
+            None,
+            &cred_def,
+            &link_secret,
+            LINK_SECRET_ID,
+            &credential_offer,
+        ).unwrap();
+
+        let json_string = serde_json::to_string(&res.1).map_err(|err| AnoncredsError::ConversionError(err.to_string())).unwrap();
+
+        let crm = CredentialRequestMetadata {
+            core: res.1
+        };
+
+        println!("{}", crm.get_json().unwrap());
+
+        assert_eq!(json_string, crm.get_json().unwrap().clone());
     }
 }


### PR DESCRIPTION
Fix for:

- AnonCred Wrapper linking issue on Android
- CredentialRequestMetadata->get_link_secret_name was being returned with double quotation
- Update Kotlin to 1.9.22 to fix different Kotlin version compatibility issue